### PR TITLE
[RTM]Requested Changes by aschempp

### DIFF
--- a/library/Terminal42/ChangeLanguage/Helper/LanguageText.php
+++ b/library/Terminal42/ChangeLanguage/Helper/LanguageText.php
@@ -97,19 +97,9 @@ class LanguageText
 
         $languages = array_keys($this->map);
 
-        /**
-         * contao itself expects the language to be in format language-COUNTRY - e.g. `en-US`, however in the below
-         * usort the method `getNormalizedLanguage()` would return en_US - thus the array_search fails in such cases
-         * if you just use the language without appending the country this issue will not surface and the usort
-         * will work as expected
-         */
-        array_walk($languages, function(&$value) {
-            $value = str_replace('-', '_', $value);
-        });
-
         usort($items, function (NavigationItem $a, NavigationItem $b) use ($languages) {
-            $key1 = array_search(strtolower($a->getNormalizedLanguage()), $languages, true);
-            $key2 = array_search(strtolower($b->getNormalizedLanguage()), $languages, true);
+            $key1 = array_search(strtolower($a->getLanguageTag()), $languages, true);
+            $key2 = array_search(strtolower($b->getLanguageTag()), $languages, true);
 
             return ($key1 < $key2) ? -1 : 1;
         });

--- a/library/Terminal42/ChangeLanguage/Tests/Helper/LanguageText/LanguageTextWithMapEntriesTest.php
+++ b/library/Terminal42/ChangeLanguage/Tests/Helper/LanguageText/LanguageTextWithMapEntriesTest.php
@@ -68,7 +68,7 @@ class LanguageTextWithMapEntriesTest extends ContaoTestCase
         $this->items[] = new NavigationItem($bazDe);
     }
 
-    public function testOrderNavigationItemsReturnsExpectedOrder()
+    public function testOrderNavigationItemsResultsInExpectedOrder()
     {
         $this->languageText->orderNavigationItems($this->items);
         $keys = array_keys($this->map);

--- a/library/Terminal42/ChangeLanguage/Tests/Helper/LanguageText/LanguageTextWithMapEntriesTest.php
+++ b/library/Terminal42/ChangeLanguage/Tests/Helper/LanguageText/LanguageTextWithMapEntriesTest.php
@@ -3,8 +3,7 @@
 /*
  * changelanguage Extension for Contao Open Source CMS
  *
- * @copyright  Copyright (c) 2008-2017, terminal42 gmbh
- * @author     terminal42 gmbh <info@terminal42.ch>
+ * @copyright  Copyright (c) CTS GmbH
  * @author     CTS GmbH <info@cts-media.eu>
  * @license    http://opensource.org/licenses/lgpl-3.0.html LGPL
  * @link       http://github.com/terminal42/contao-changelanguage
@@ -30,7 +29,7 @@ class LanguageTextWithMapEntriesTest extends ContaoTestCase
     private $items;
 
     /**
-     * @var array
+     * @var array this defined both the displayed text AND the sorting order
      */
     private $map = [
         'en'    => 'International',
@@ -61,7 +60,7 @@ class LanguageTextWithMapEntriesTest extends ContaoTestCase
         $helloFr = PageModel::findById($helloFrId);
         $worldPl = PageModel::findById($worldPlId);
 
-        //items do not get added in "correct" order on purpose
+        //items do not get added in "correct" order on purpose to test the sorting
         $this->items[] = new NavigationItem($barCh);
         $this->items[] = new NavigationItem($worldPl);
         $this->items[] = new NavigationItem($fooCom);
@@ -69,7 +68,7 @@ class LanguageTextWithMapEntriesTest extends ContaoTestCase
         $this->items[] = new NavigationItem($bazDe);
     }
 
-    public function testOrderNavigationItemsWithMixedLanguageTags()
+    public function testOrderNavigationItemsReturnsExpectedOrder()
     {
         $this->languageText->orderNavigationItems($this->items);
         $keys = array_keys($this->map);

--- a/library/Terminal42/ChangeLanguage/Tests/Helper/LanguageText/LanguageTextWithMapEntriesTest.php
+++ b/library/Terminal42/ChangeLanguage/Tests/Helper/LanguageText/LanguageTextWithMapEntriesTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * changelanguage Extension for Contao Open Source CMS
+ *
+ * @copyright  Copyright (c) 2008-2017, terminal42 gmbh
+ * @author     terminal42 gmbh <info@terminal42.ch>
+ * @author     CTS GmbH <info@cts-media.eu>
+ * @license    http://opensource.org/licenses/lgpl-3.0.html LGPL
+ * @link       http://github.com/terminal42/contao-changelanguage
+ */
+
+namespace Terminal42\ChangeLanguage\Tests\Helper;
+
+use Contao\PageModel;
+use Terminal42\ChangeLanguage\Helper\LanguageText;
+use Terminal42\ChangeLanguage\Navigation\NavigationItem;
+use Terminal42\ChangeLanguage\Tests\ContaoTestCase;
+
+class LanguageTextWithMapEntriesTest extends ContaoTestCase
+{
+    /**
+     * @var LanguageText
+     */
+    private $languageText;
+
+    /**
+     * @var NavigationItem[]
+     */
+    private $items;
+
+    /**
+     * @var array
+     */
+    private $map = [
+        'en'    => 'International',
+        'de-CH' => 'Switzerland (German)',
+        'de'    => 'Germany',
+        'fr-FR' => 'France',
+        'pl'    => 'Poland',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->languageText = new LanguageText($this->map);
+
+        $fooComId = $this->createRootPage('foo.com', 'en');
+        $barChId = $this->createRootPage('bar.ch', 'de-CH');
+        $bazDeId = $this->createRootPage('baz.de', 'de');
+        $helloFrId = $this->createRootPage('hello.fr', 'fr-FR');
+        $worldPlId = $this->createRootPage('world.pl', 'pl');
+
+        $fooCom = PageModel::findById($fooComId);
+        $barCh = PageModel::findById($barChId);
+        $bazDe = PageModel::findById($bazDeId);
+        $helloFr = PageModel::findById($helloFrId);
+        $worldPl = PageModel::findById($worldPlId);
+
+        //items do not get added in "correct" order on purpose
+        $this->items[] = new NavigationItem($barCh);
+        $this->items[] = new NavigationItem($worldPl);
+        $this->items[] = new NavigationItem($fooCom);
+        $this->items[] = new NavigationItem($helloFr);
+        $this->items[] = new NavigationItem($bazDe);
+    }
+
+    public function testOrderNavigationItemsWithMixedLanguageTags()
+    {
+        $this->languageText->orderNavigationItems($this->items);
+        $keys = array_keys($this->map);
+
+        foreach ($this->items as $item) {
+            //items order should be equal to the order in the map which was passed to LanguageText
+            $this->assertEquals(array_shift($keys), $item->getLanguageTag());
+        }
+    }
+
+    private function createRootPage($dns, $language)
+    {
+        return $this->query("
+            INSERT INTO tl_page 
+            (type, title, dns, language, published) 
+            VALUES 
+            ('root', 'foobar', '$dns', '$language', '1')
+        ");
+    }
+}


### PR DESCRIPTION
Requested: https://github.com/terminal42/contao-changelanguage/pull/134#issuecomment-325897021

- use `getLanguageTag` instead of `getNormalizedLanguage` and remove array_walk / str_replace combination
- add unittest for LanguageText where the ordering is tested

@DanielSchwiperich please check it - mainly if you agree / disagree with the unit testcase. I tried to kept it somewhat close to the other testcases I found in there

## ToDo

- [x] Rebase our master after merge so we do not clutter up the original repo with superfluous commits