### PR TITLE
Feature: limit to root pages

### DIFF
--- a/dca/tl_module.php
+++ b/dca/tl_module.php
@@ -14,10 +14,10 @@
  * Palettes
  */
 $GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][]       = 'customLanguage';
-$GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][]       = 'limitToRootPages';
-$GLOBALS['TL_DCA']['tl_module']['palettes']['changelanguage']       = '{title_legend},name,headline,type;{config_legend},hideActiveLanguage,hideNoFallback,customLanguage,limitToRootPages;{template_legend:hide},navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
+$GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][]       = 'limitWebsiteRoots';
+$GLOBALS['TL_DCA']['tl_module']['palettes']['changelanguage']       = '{title_legend},name,headline,type;{config_legend},hideActiveLanguage,hideNoFallback,customLanguage,limitWebsiteRoots;{template_legend:hide},navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
 $GLOBALS['TL_DCA']['tl_module']['subpalettes']['customLanguage']    = 'customLanguageText';
-$GLOBALS['TL_DCA']['tl_module']['subpalettes']['limitToRootPages']  = 'rootPageIds,negateRootPageIds';
+$GLOBALS['TL_DCA']['tl_module']['subpalettes']['limitWebsiteRoots']  = 'websiteRootPageIds,negateWebsiteRootsSelection';
 
 
 /**
@@ -77,28 +77,28 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['customLanguageText'] = array
     'sql'                     => "text NULL"
 );
 
-$GLOBALS['TL_DCA']['tl_module']['fields']['limitToRootPages'] = array
+$GLOBALS['TL_DCA']['tl_module']['fields']['limitWebsiteRoots'] = array
 (
-    'label'                   => &$GLOBALS['TL_LANG']['tl_module']['limitToRootPages'],
+    'label'                   => &$GLOBALS['TL_LANG']['tl_module']['limitWebsiteRoots'],
     'exclude'                 => true,
     'inputType'               => 'checkbox',
     'eval'                    => ['submitOnChange' => true, 'tl_class' => 'clr'],
     'sql'                     => "char(1) NOT NULL default ''"
 );
 
-$GLOBALS['TL_DCA']['tl_module']['fields']['rootPageIds'] = array
+$GLOBALS['TL_DCA']['tl_module']['fields']['websiteRootPageIds'] = array
 (
-    'label'                   => &$GLOBALS['TL_LANG']['tl_module']['rootPageIds'],
+    'label'                   => &$GLOBALS['TL_LANG']['tl_module']['websiteRootPageIds'],
     'exclude'                 => true,
     'inputType'               => 'select',
-    'options_callback'        => array('Terminal42\ChangeLanguage\EventListener\DataContainer\ModuleFieldsListener', 'onRootPageIdsOptions'),
+    'options_callback'        => array('Terminal42\ChangeLanguage\EventListener\DataContainer\ModuleFieldsListener', 'onWebsiteRootPageIdsOptions'),
     'eval'                    => ['mandatory' => true, 'multiple' => true, 'chosen' => true, 'csv' => ',', 'tl_class' => 'clr'],
     'sql'                     => "TEXT null"
 );
 
-$GLOBALS['TL_DCA']['tl_module']['fields']['negateRootPageIds'] = array
+$GLOBALS['TL_DCA']['tl_module']['fields']['negateWebsiteRootsSelection'] = array
 (
-    'label'                   => &$GLOBALS['TL_LANG']['tl_module']['negateRootPageIds'],
+    'label'                   => &$GLOBALS['TL_LANG']['tl_module']['negateWebsiteRootsSelection'],
     'exclude'                 => true,
     'inputType'               => 'checkbox',
     'eval'                    => ['tl_class' => 'clr'],

--- a/dca/tl_module.php
+++ b/dca/tl_module.php
@@ -14,8 +14,10 @@
  * Palettes
  */
 $GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][]       = 'customLanguage';
-$GLOBALS['TL_DCA']['tl_module']['palettes']['changelanguage']       = '{title_legend},name,headline,type;{config_legend},hideActiveLanguage,hideNoFallback,customLanguage;{template_legend:hide},navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
+$GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][]       = 'limitToRootPages';
+$GLOBALS['TL_DCA']['tl_module']['palettes']['changelanguage']       = '{title_legend},name,headline,type;{config_legend},hideActiveLanguage,hideNoFallback,customLanguage,limitToRootPages;{template_legend:hide},navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
 $GLOBALS['TL_DCA']['tl_module']['subpalettes']['customLanguage']    = 'customLanguageText';
+$GLOBALS['TL_DCA']['tl_module']['subpalettes']['limitToRootPages']  = 'rootPageIds,negateRootPageIds';
 
 
 /**
@@ -73,4 +75,32 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['customLanguageText'] = array
         'tl_class'     => 'clr',
     ),
     'sql'                     => "text NULL"
+);
+
+$GLOBALS['TL_DCA']['tl_module']['fields']['limitToRootPages'] = array
+(
+    'label'                   => &$GLOBALS['TL_LANG']['tl_module']['limitToRootPages'],
+    'exclude'                 => true,
+    'inputType'               => 'checkbox',
+    'eval'                    => ['submitOnChange' => true, 'tl_class' => 'clr'],
+    'sql'                     => "char(1) NOT NULL default ''"
+);
+
+$GLOBALS['TL_DCA']['tl_module']['fields']['rootPageIds'] = array
+(
+    'label'                   => &$GLOBALS['TL_LANG']['tl_module']['rootPageIds'],
+    'exclude'                 => true,
+    'inputType'               => 'select',
+    'options_callback'        => array('Terminal42\ChangeLanguage\EventListener\DataContainer\ModuleFieldsListener', 'onRootPageIdsOptions'),
+    'eval'                    => ['mandatory' => true, 'multiple' => true, 'chosen' => true, 'csv' => ',', 'tl_class' => 'clr'],
+    'sql'                     => "TEXT null"
+);
+
+$GLOBALS['TL_DCA']['tl_module']['fields']['negateRootPageIds'] = array
+(
+    'label'                   => &$GLOBALS['TL_LANG']['tl_module']['negateRootPageIds'],
+    'exclude'                 => true,
+    'inputType'               => 'checkbox',
+    'eval'                    => ['tl_class' => 'clr'],
+    'sql'                     => "char(1) NOT NULL default ''"
 );

--- a/languages/de/tl_module.xlf
+++ b/languages/de/tl_module.xlf
@@ -47,6 +47,30 @@
                 <source>Replacement text</source>
                 <target>Ersatztext</target>
             </trans-unit>
+            <trans-unit id="tl_module.limitWebsiteRoots.0">
+                <source>Limit Website Roots in Navigation</source>
+                <target>Anzeigen von Website Roots begrenzen</target>
+            </trans-unit>
+            <trans-unit id="tl_module.limitWebsiteRoots.1">
+                <source>Turning this on will allow you to determine which website roots should be shown in the navigation.</source>
+                <target>Aktiviert die Möglichkeit die anzuzeigenden Website Roots zu begrenzen</target>
+            </trans-unit>
+            <trans-unit id="tl_module.websiteRootPageIds.0">
+                <source>Website Roots</source>
+                <target>Website Roots</target>
+            </trans-unit>
+            <trans-unit id="tl_module.websiteRootPageIds.1">
+                <source>Choose the Website Roots you want to include / exclude (depends on the below checkbox).</source>
+                <target>Wähle die Website Roots aus, die einbezogen / ausgeschlossen (Abhängig von unterer Checkbox) werden.</target>
+            </trans-unit>
+            <trans-unit id="tl_module.negateWebsiteRootsSelection.0">
+                <source>Exclude Selection</source>
+                <target>Auswahl ausschließen</target>
+            </trans-unit>
+            <trans-unit id="tl_module.negateWebsiteRootsSelection.1">
+                <source>All pages in the Selection will be excluded.</source>
+                <target>Alle Seiten in der Auswahl werden ausgeschlossen</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/languages/en/tl_module.xlf
+++ b/languages/en/tl_module.xlf
@@ -37,6 +37,24 @@
             <trans-unit id="tl_module.customLanguageText.label">
                 <source>Replacement text</source>
             </trans-unit>
+            <trans-unit id="tl_module.limitWebsiteRoots.0">
+                <source>Limit Website Roots in Navigation</source>
+            </trans-unit>
+            <trans-unit id="tl_module.limitWebsiteRoots.1">
+                <source>Turning this on will allow you to determine which website roots should be shown in the navigation.</source>
+            </trans-unit>
+            <trans-unit id="tl_module.websiteRootPageIds.0">
+                <source>Website Roots</source>
+            </trans-unit>
+            <trans-unit id="tl_module.websiteRootPageIds.1">
+                <source>Choose the Website Roots you want to include / exclude (depends on the below checkbox).</source>
+            </trans-unit>
+            <trans-unit id="tl_module.negateWebsiteRootsSelection.0">
+                <source>Exclude Selection</source>
+            </trans-unit>
+            <trans-unit id="tl_module.negateWebsiteRootsSelection.1">
+                <source>All pages in the Selection will be excluded.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/library/Terminal42/ChangeLanguage/EventListener/DataContainer/ModuleFieldsListener.php
+++ b/library/Terminal42/ChangeLanguage/EventListener/DataContainer/ModuleFieldsListener.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * changelanguage Extension for Contao Open Source CMS
+ *
+ * @copyright  Copyright (c) 2008-2017, terminal42 gmbh
+ * @author     terminal42 gmbh <info@terminal42.ch>
+ * @author     CTS GmbH <info@cts-media.eu>
+ * @license    http://opensource.org/licenses/lgpl-3.0.html LGPL
+ * @link       http://github.com/terminal42/contao-changelanguage
+ */
+
+namespace Terminal42\ChangeLanguage\EventListener\DataContainer;
+
+use Contao\PageModel;
+
+class ModuleFieldsListener
+{
+    /**
+     * Gets list of options for root page limit selection (to only render certain root pages in frontend output).
+     *
+     * @return array
+     */
+    public function onRootPageIdsOptions()
+    {
+        /** @var PageModel[] $pages */
+        $pages = PageModel::findBy(['tl_page.type=?'], ['root']);
+
+        if (null === $pages) {
+            return [];
+        }
+
+        $options = [];
+
+        foreach ($pages as $page) {
+            $options[$page->id] = sprintf(
+                '%s%s [%s]',
+                $page->title,
+                (strlen($page->dns) ? (' ('.$page->dns.')') : ''),
+                $page->language
+            );
+        }
+
+        return $options;
+    }
+}

--- a/library/Terminal42/ChangeLanguage/EventListener/DataContainer/ModuleFieldsListener.php
+++ b/library/Terminal42/ChangeLanguage/EventListener/DataContainer/ModuleFieldsListener.php
@@ -21,7 +21,7 @@ class ModuleFieldsListener
      *
      * @return array
      */
-    public function onRootPageIdsOptions()
+    public function onWebsiteRootPageIdsOptions()
     {
         /** @var PageModel[] $pages */
         $pages = PageModel::findBy(['tl_page.type=?'], ['root']);

--- a/library/Terminal42/ChangeLanguage/FrontendModule/ChangeLanguageModule.php
+++ b/library/Terminal42/ChangeLanguage/FrontendModule/ChangeLanguageModule.php
@@ -59,11 +59,11 @@ class ChangeLanguageModule extends AbstractFrontendModule
     {
         $currentPage = $this->getCurrentPage();
 
-        if ($this->limitToRootPages) {
-            $rootPageIds = explode(',', $this->rootPageIds);
-            $negateRootPageIds = (bool)$this->negateRootPageIds;
+        if ($this->limitWebsiteRoots) {
+            $websiteRootPageIds = explode(',', $this->websiteRootPageIds);
+            $negateWebsiteRootsSelection = (bool)$this->negateWebsiteRootsSelection;
 
-            $pageFinder = new PageFinder($rootPageIds, $negateRootPageIds);
+            $pageFinder = new PageFinder($websiteRootPageIds, $negateWebsiteRootsSelection);
         } else {
             $pageFinder = new PageFinder();
         }

--- a/library/Terminal42/ChangeLanguage/FrontendModule/ChangeLanguageModule.php
+++ b/library/Terminal42/ChangeLanguage/FrontendModule/ChangeLanguageModule.php
@@ -60,7 +60,7 @@ class ChangeLanguageModule extends AbstractFrontendModule
         $currentPage = $this->getCurrentPage();
 
         if ($this->limitToRootPages) {
-            $rootPageIds = $this->getRootPageIds();
+            $rootPageIds = explode(',', $this->rootPageIds);
             $negateRootPageIds = (bool)$this->negateRootPageIds;
 
             $pageFinder = new PageFinder($rootPageIds, $negateRootPageIds);
@@ -163,40 +163,6 @@ class ChangeLanguageModule extends AbstractFrontendModule
         global $objPage;
 
         return $objPage;
-    }
-
-    /**
-     * @return array
-     */
-    protected function getRootPageIds()
-    {
-        $rootPageIds = explode(',', $this->rootPageIds);
-        $negateRootPageIds = (bool)$this->negateRootPageIds;
-        $currentPage = $this->getCurrentPage();
-
-        /**
-         * usecase: you want to show all rootPageIds which are NOT configured in the module config
-         * if the rootId of the current page is part of the list, we need to remove it - if its not removed then the
-         * active page will not be shown in the list
-         */
-        if ($negateRootPageIds && in_array($currentPage->rootId, $rootPageIds)) {
-            $key = array_search($currentPage->rootId, $rootPageIds);
-
-            if ($key !== false) {
-                unset($rootPageIds[$key]);
-            }
-        }
-
-        /**
-         * usecase: you want to show all rootPageIds which are configured in the module config
-         * if the rootId of the current page is NOT part of the list, we need to add it - if its not added then the
-         * active page will not be shown in the list
-         */
-        if (!$negateRootPageIds && !in_array($currentPage->rootId, $rootPageIds)) {
-            $rootPageIds[] = $currentPage->rootId;
-        }
-
-        return $rootPageIds;
     }
 
     /**

--- a/library/Terminal42/ChangeLanguage/PageFinder.php
+++ b/library/Terminal42/ChangeLanguage/PageFinder.php
@@ -293,7 +293,7 @@ class PageFinder
 
             $negation = ($this->negateWebsiteRootsSelection)? 'NOT' : '';
 
-            $columns[] = "$table.id $negation IN($placeholders)";
+            $columns[] = "$table.id ${negation} IN(${placeholders})";
             $values = array_merge($values, $websiteRootPageIds);
         }
     }

--- a/library/Terminal42/ChangeLanguage/PageFinder.php
+++ b/library/Terminal42/ChangeLanguage/PageFinder.php
@@ -39,7 +39,7 @@ class PageFinder
             $this->rootPageIds[] = intval($id);
         }
 
-        $this->negateRootPageIds = $negateRootPageIds;
+        $this->negateRootPageIds = (bool)$negateRootPageIds;
     }
 
     /**

--- a/library/Terminal42/ChangeLanguage/PageFinder.php
+++ b/library/Terminal42/ChangeLanguage/PageFinder.php
@@ -20,26 +20,26 @@ class PageFinder
     /**
      * @var array
      */
-    private $rootPageIds;
+    private $websiteRootPageIds;
 
     /**
      * @var bool
      */
-    private $negateRootPageIds;
+    private $negateWebsiteRootsSelection;
 
     /**
      * Constructor.
      *
-     * @param array $rootPageIds limits result to given root pages
-     * @param bool  $negateRootPageIds if true, negates the condition so all but the given $rootPageIds are found
+     * @param array $websiteRootPageIds          limits result to given root pages
+     * @param bool  $negateWebsiteRootsSelection if true, negates condition so all but the given $websiteRootPageIds are found
      */
-    public function __construct(array $rootPageIds = [], $negateRootPageIds = false)
+    public function __construct(array $websiteRootPageIds = [], $negateWebsiteRootsSelection = false)
     {
-        foreach(array_unique($rootPageIds) as $id) {
-            $this->rootPageIds[] = intval($id);
+        foreach(array_unique($websiteRootPageIds) as $id) {
+            $this->websiteRootPageIds[] = intval($id);
         }
 
-        $this->negateRootPageIds = (bool)$negateRootPageIds;
+        $this->negateWebsiteRootsSelection = (bool)$negateWebsiteRootsSelection;
     }
 
     /**
@@ -93,7 +93,7 @@ class PageFinder
             $this->addPublishingConditions($columns, $t);
         }
 
-        $this->addLimitRootPageIdsCondition($columns, $values, $t, $page);
+        $this->addWebsiteRootPageIdsCondition($columns, $values, $t, $page);
 
         return $this->findPages($columns, $values, ['order' => 'sorting']);
     }
@@ -123,7 +123,7 @@ class PageFinder
 
         $values = [$page->domain, $page->domain, $page->domain];
 
-        $this->addLimitRootPageIdsCondition($columns, $values, $t, $page);
+        $this->addWebsiteRootPageIdsCondition($columns, $values, $t, $page);
 
         return PageModel::findOneBy($columns, $values);
     }
@@ -280,21 +280,21 @@ class PageFinder
      * @param array  $values
      * @param string $table
      */
-    private function addLimitRootPageIdsCondition(array &$columns, array &$values, $table, PageModel $page)
+    private function addWebsiteRootPageIdsCondition(array &$columns, array &$values, $table, PageModel $page)
     {
-        if (count($this->rootPageIds)) {
-            $rootPageIds = $this->addCurrentPageRootToSelection($page, ...$this->rootPageIds);
+        if (count($this->websiteRootPageIds)) {
+            $websiteRootPageIds = $this->addCurrentPageRootToSelection($page, ...$this->websiteRootPageIds);
 
             /**
              * this will generate a comma separated string of placeholders
-             * example: if there are 5 entries in rootPageIds it will generate the following string: ?,?,?,?,?
+             * example: if there are 5 entries in websiteRootPageIds it will generate the following string: ?,?,?,?,?
              */
-            $placeholders = (implode(',', array_pad([], count($rootPageIds), '?')));
+            $placeholders = (implode(',', array_pad([], count($websiteRootPageIds), '?')));
 
-            $negation = ($this->negateRootPageIds)? 'NOT' : '';
+            $negation = ($this->negateWebsiteRootsSelection)? 'NOT' : '';
 
             $columns[] = "$table.id $negation IN($placeholders)";
-            $values = array_merge($values, $rootPageIds);
+            $values = array_merge($values, $websiteRootPageIds);
         }
     }
 
@@ -323,30 +323,30 @@ class PageFinder
         return $models;
     }
 
-    private function addCurrentPageRootToSelection(PageModel $page, int ...$rootPageIds)
+    private function addCurrentPageRootToSelection(PageModel $page, int ...$websiteRootPageIds)
     {
         /**
-         * usecase: you want to show all rootPageIds which are NOT configured in the module config
+         * usecase: you want to show all websiteRootPageIds which are NOT configured in the module config
          * if the rootId of the current page is part of the list, we need to remove it - if its not removed then the
          * active page will not be shown in the list
          */
-        if ($this->negateRootPageIds && in_array($page->rootId, $rootPageIds)) {
-            $key = array_search($page->rootId, $rootPageIds);
+        if ($this->negateWebsiteRootsSelection && in_array($page->rootId, $websiteRootPageIds)) {
+            $key = array_search($page->rootId, $websiteRootPageIds);
 
             if ($key !== false) {
-                unset($rootPageIds[$key]);
+                unset($websiteRootPageIds[$key]);
             }
         }
 
         /**
-         * usecase: you want to show all rootPageIds which are configured in the module config
+         * usecase: you want to show all websiteRootPageIds which are configured in the module config
          * if the rootId of the current page is NOT part of the list, we need to add it - if its not added then the
          * active page will not be shown in the list
          */
-        if (!$this->negateRootPageIds && !in_array($page->rootId, $rootPageIds)) {
-            $rootPageIds[] = $page->rootId;
+        if (!$this->negateWebsiteRootsSelection && !in_array($page->rootId, $websiteRootPageIds)) {
+            $websiteRootPageIds[] = $page->rootId;
         }
 
-        return $rootPageIds;
+        return $websiteRootPageIds;
     }
 }

--- a/library/Terminal42/ChangeLanguage/Tests/PageFinder/RootPagesLimitNegationTest.php
+++ b/library/Terminal42/ChangeLanguage/Tests/PageFinder/RootPagesLimitNegationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * changelanguage Extension for Contao Open Source CMS
+ *
+ * @copyright  Copyright (c) 2008-2017, terminal42 gmbh
+ * @author     terminal42 gmbh <info@terminal42.ch>
+ * @author     CTS GmbH <info@cts-media.eu>
+ * @license    http://opensource.org/licenses/lgpl-3.0.html LGPL
+ * @link       http://github.com/terminal42/contao-changelanguage
+ */
+
+namespace Terminal42\ChangeLanguage\Tests\PageFinder;
+
+use Contao\PageModel;
+use Terminal42\ChangeLanguage\PageFinder;
+use Terminal42\ChangeLanguage\Tests\ContaoTestCase;
+
+class RootPagesLimitNegationTest extends ContaoTestCase
+{
+    /**
+     * @var PageFinder
+     */
+    private $pageFinder;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->pageFinder = new PageFinder([1], true);
+    }
+
+    public function testOnlyExcludesConfiguredRootIds()
+    {
+        $id = $this->createRootPage('foo.com', 'en', true);
+        $this->createRootPage('foo.com', 'de', false);
+        $this->createRootPage('foo.com', 'fr', false);
+        $this->createRootPage('foo.com', 'it', false);
+
+        $regularId = $this->createRegularPage($id);
+
+        $pageModel = new PageModel();
+        $pageModel->id = $regularId;
+        $pageModel->pid = $id;
+
+        $roots = $this->pageFinder->findRootPagesForPage($pageModel);
+
+        $this->assertPageCount($roots, 3);
+    }
+
+    private function createRootPage($dns, $language, $fallback = true, $published = true)
+    {
+        $fallback = $fallback ? '1' : '';
+        $published = $published ? '1' : '';
+
+        return $this->query("
+            INSERT INTO tl_page 
+            (type, title, dns, language, fallback, published) 
+            VALUES 
+            ('root', 'foobar', '$dns', '$language', '$fallback', '$published')
+        ");
+    }
+
+    private function createRegularPage($pid)
+    {
+        return $this->query("
+            INSERT INTO tl_page 
+            (pid, type, title, published) 
+            VALUES 
+            ('$pid', 'regular', 'barbaz', '1')
+        ");
+    }
+
+    private function assertPageCount($roots, $count)
+    {
+        $this->assertCount($count, $roots);
+
+        foreach ($roots as $instance) {
+            $this->assertInstanceOf('\Contao\PageModel', $instance);
+        }
+    }
+}

--- a/library/Terminal42/ChangeLanguage/Tests/PageFinder/RootPagesLimitTest.php
+++ b/library/Terminal42/ChangeLanguage/Tests/PageFinder/RootPagesLimitTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * changelanguage Extension for Contao Open Source CMS
+ *
+ * @copyright  Copyright (c) 2008-2017, terminal42 gmbh
+ * @author     terminal42 gmbh <info@terminal42.ch>
+ * @author     CTS GmbH <info@cts-media.eu>
+ * @license    http://opensource.org/licenses/lgpl-3.0.html LGPL
+ * @link       http://github.com/terminal42/contao-changelanguage
+ */
+
+namespace Terminal42\ChangeLanguage\Tests\PageFinder;
+
+use Contao\PageModel;
+use Terminal42\ChangeLanguage\PageFinder;
+use Terminal42\ChangeLanguage\Tests\ContaoTestCase;
+
+class RootPagesLimitTest extends ContaoTestCase
+{
+    /**
+     * @var PageFinder
+     */
+    private $pageFinder;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->pageFinder = new PageFinder([1, 2]);
+    }
+
+    public function testOnlyIncludesConfiguredRootIds()
+    {
+        $id = $this->createRootPage('foo.com', 'en', true);
+        $this->createRootPage('foo.com', 'de', false);
+        $this->createRootPage('foo.com', 'fr', false);
+        $this->createRootPage('foo.com', 'it', false);
+
+        $regularId = $this->createRegularPage($id);
+
+        $pageModel = new PageModel();
+        $pageModel->id = $regularId;
+        $pageModel->pid = $id;
+
+        $roots = $this->pageFinder->findRootPagesForPage($pageModel);
+
+        $this->assertPageCount($roots, 2);
+    }
+
+    private function createRootPage($dns, $language, $fallback = true, $published = true)
+    {
+        $fallback = $fallback ? '1' : '';
+        $published = $published ? '1' : '';
+
+        return $this->query("
+            INSERT INTO tl_page 
+            (type, title, dns, language, fallback, published) 
+            VALUES 
+            ('root', 'foobar', '$dns', '$language', '$fallback', '$published')
+        ");
+    }
+
+    private function createRegularPage($pid)
+    {
+        return $this->query("
+            INSERT INTO tl_page 
+            (pid, type, title, published) 
+            VALUES 
+            ('$pid', 'regular', 'barbaz', '1')
+        ");
+    }
+
+    private function assertPageCount($roots, $count)
+    {
+        $this->assertCount($count, $roots);
+
+        foreach ($roots as $instance) {
+            $this->assertInstanceOf('\Contao\PageModel', $instance);
+        }
+    }
+}


### PR DESCRIPTION
- added three new dca fields (`limitToRootPages`, `rootPageIds`, `negateRootPageIds`)
- added ModuleFieldsListener class for `options_callback` of `rootPageIds`
- added constructor to `PageFinder` with two optional parameters (to avoid breaking already existing code) - `$rootPageIds` for an array of root ids and `$negateRootPageIds` which will negate the sql condition (`IN()` to `NOT IN()`)
- added method `addLimitRootPageIdsCondition` to `PageFinder` which adds the `IN()` or `NOT IN()` condition to the methods `findRootPagesForPage` and `findMasterRootForPage`
- added config handling to `ChangeLanguageModule` to instance `PageFinder` with the new config settings - the class also has a `getRootPageIds` method because based on the config we may need to add or remove the rootId of the current page (see docblocks for details)
- added unittests for
  - limiting rootPages (only the choosen root pages are shown in the FE language navigation)
  - negating the list of rootPages (only pages NOT in the list are shown in the FE language navigation)

## ToDo

- [x] Talk to terminal42 if they are interested in this as PR (https://github.com/terminal42/contao-changelanguage/issues/135)
  - ~~If yes Talk to terminal42 about Transifex translations and how they want them done (currently missing)~~
  - [x] If no, we will just add the translations manually to xlf files in our repo